### PR TITLE
Allow selecting from prompt history

### DIFF
--- a/lib/rake_commit/prompt_history.rb
+++ b/lib/rake_commit/prompt_history.rb
@@ -1,13 +1,8 @@
-require 'forwardable'
 require 'readline'
 require 'tmpdir'
 
 module RakeCommit
   class PromptHistory
-
-    extend Forwardable
-
-    def_delegators :history, :last, :empty?
 
     def initialize(attribute)
       @attribute = attribute
@@ -15,6 +10,10 @@ module RakeCommit
 
     def save(input)
       File.open(save_path, "a") { |f| f.write(input + "\n") }
+    end
+
+    def previous_input
+      history.last
     end
 
     private

--- a/lib/rake_commit/prompt_line.rb
+++ b/lib/rake_commit/prompt_line.rb
@@ -13,7 +13,7 @@ module RakeCommit
       input = nil
       loop do
         input = Readline.readline(message).chomp
-        break unless (input.empty? && history.empty?)
+        break unless (input.empty? && !previous_input)
       end
 
       unless input.empty?
@@ -27,7 +27,7 @@ module RakeCommit
 
     def message
       previous_message = "\n"
-      previous_message += "previous #{@attribute}: #{previous_input}\n" unless previous_input.nil?
+      previous_message += "previous #{@attribute}: #{previous_input}\n" if previous_input
       puts previous_message
       "#{@attribute}: "
     end
@@ -38,7 +38,7 @@ module RakeCommit
     end
 
     def previous_input
-      @previous_input ||= history.last
+      @previous_input ||= history.previous_input
     end
   end
 end

--- a/test/prompt_history_test.rb
+++ b/test/prompt_history_test.rb
@@ -8,23 +8,10 @@ class PromptHistoryTest < Test::Unit::TestCase
     RakeCommit::PromptHistory.new("feature").save("card 100")
   end
 
-  def test_last_will_return_last_saved_value
+  def test_previous_input_will_return_last_saved_value
     File.expects(:exists?).with(Dir.tmpdir + "/feature.data").returns(true)
     File.expects(:read).with(Dir.tmpdir + "/feature.data").returns("card 100\ncard 101\n")
     Readline::HISTORY.expects(:push).with("card 100", "card 101").returns(["card 100", "card 101"])
-    assert_equal "card 101", RakeCommit::PromptHistory.new("feature").last
-  end
-
-  def test_empty_will_return_true_with_empty_history
-    File.expects(:exists?).with(Dir.tmpdir + "/feature.data").returns(false)
-    Readline::HISTORY.expects(:push).with(nil).returns([])
-    assert_equal true, RakeCommit::PromptHistory.new("feature").empty?
-  end
-
-  def test_empty_will_return_false_with_existent_history
-    File.expects(:exists?).with(Dir.tmpdir + "/feature.data").returns(true)
-    File.expects(:read).with(Dir.tmpdir + "/feature.data").returns("card 100\n")
-    Readline::HISTORY.expects(:push).with("card 100").returns(["card 100"])
-    assert_equal false, RakeCommit::PromptHistory.new("feature").empty?
+    assert_equal "card 101", RakeCommit::PromptHistory.new("feature").previous_input
   end
 end

--- a/test/prompt_line_test.rb
+++ b/test/prompt_line_test.rb
@@ -3,13 +3,13 @@ require File.expand_path(File.dirname(__FILE__) + "/test_helper")
 class PromptLineTest < Test::Unit::TestCase
 
   def test_message_puts_newline_if_saved_attribute_does_not_exist
-    RakeCommit::PromptHistory.any_instance.expects(:last).returns(nil)
+    RakeCommit::PromptHistory.any_instance.expects(:previous_input).returns(nil)
     RakeCommit::PromptLine.any_instance.expects(:puts).with("\n")
     assert_equal "pair: ", RakeCommit::PromptLine.new("pair").message
   end
 
   def test_message_puts_saved_attribute_if_exists
-    RakeCommit::PromptHistory.any_instance.expects(:last).returns("John Doe")
+    RakeCommit::PromptHistory.any_instance.expects(:previous_input).returns("John Doe")
     RakeCommit::PromptLine.any_instance.expects(:puts).with("\nprevious pair: John Doe\n")
     assert_equal "pair: ", RakeCommit::PromptLine.new("pair").message
   end


### PR DESCRIPTION
This allows you to scroll up to previous inputs for each prompt. It can come in handy if want to slightly modify previous input for new input e.g., slightly modifying your previous commit message for a new commit.
