### PR TITLE
Use readline history to provide prompt history

### DIFF
--- a/lib/rake_commit/prompt_line.rb
+++ b/lib/rake_commit/prompt_line.rb
@@ -35,7 +35,7 @@ module RakeCommit
     end
 
     def save_history(input)
-      File.open(history_file, "w") { |f| f.puts(history.push(input)) }
+      File.open(history_file, "a") { |f| f.puts(input) }
     end
 
     private
@@ -48,9 +48,13 @@ module RakeCommit
     end
 
     def load_history
-      HISTORY.clear
-      HISTORY.push(*File.read(history_file).split("\n")) if File.exists?(history_file)
+      HISTORY.pop until HISTORY.empty?
+      HISTORY.push(*saved_history)
       HISTORY.to_a
+    end
+
+    def saved_history
+      File.exists?(history_file) ? File.read(history_file).split("\n") : []
     end
 
     def history_file

--- a/test/prompt_line_test.rb
+++ b/test/prompt_line_test.rb
@@ -10,23 +10,14 @@ class PromptLineTest < Test::Unit::TestCase
 
   def test_message_puts_last_saved_attribute_if_exists
     File.expects(:exists?).with(Dir.tmpdir + "/pair.data").returns(true)
-    File.expects(:read).with(Dir.tmpdir + "/pair.data").returns("Jane Doe\nJohn Doe")
+    File.expects(:read).with(Dir.tmpdir + "/pair.data").returns("Jane Doe\nJohn Doe\n")
     RakeCommit::PromptLine.any_instance.expects(:puts).with("\nprevious pair: John Doe\n")
     assert_equal "pair: ", RakeCommit::PromptLine.new("pair").message
   end
 
-  def test_save_history_will_save_entered_value_to_disk_with_no_history
-    File.expects(:exists?).with(Dir.tmpdir + "/feature.data").returns(false)
-    File.expects(:open).with(Dir.tmpdir + "/feature.data", "w").yields(file = mock)
-    file.expects(:puts).with(["card 100"])
-    RakeCommit::PromptLine.new("feature").save_history("card 100")
-  end
-
-  def test_save_history_will_save_entered_value_to_disk_with_existing_history
-    File.expects(:exists?).with(Dir.tmpdir + "/feature.data").returns(true)
-    File.expects(:read).with(Dir.tmpdir + "/feature.data").returns("card 90")
-    File.expects(:open).with(Dir.tmpdir + "/feature.data", "w").yields(file = mock)
-    file.expects(:puts).with(["card 90", "card 100"])
+  def test_save_history_will_save_entered_value_to_disk
+    File.expects(:open).with(Dir.tmpdir + "/feature.data", "a").yields(file = mock)
+    file.expects(:puts).with("card 100")
     RakeCommit::PromptLine.new("feature").save_history("card 100")
   end
 


### PR DESCRIPTION
This allows the user to scroll through previously entered inputs for each prompt via up/down keys.
