### PR TITLE
fixes #11 - adds a precommit flag

### DIFF
--- a/lib/rake_commit/commit.rb
+++ b/lib/rake_commit/commit.rb
@@ -1,5 +1,6 @@
 require 'optparse'
 require 'rexml/document'
+require 'shellwords'
 
 module RakeCommit
   class Commit
@@ -22,14 +23,14 @@ module RakeCommit
 
       if File.exists?(".rake_commit")
         defaults = File.read(".rake_commit")
-        options = parse_options(defaults.split(" "), options)
+        options = parse_options(Shellwords.split(defaults), options)
       end
       options = parse_options(ARGV, options)
 
       if git_svn?
         RakeCommit::GitSvn.new(options[:prompt_exclusions]).commit
       elsif git?
-        RakeCommit::Git.new(options[:collapse_commits], options[:incremental], options[:prompt_exclusions]).commit
+        RakeCommit::Git.new(options[:collapse_commits], options[:incremental], options[:prompt_exclusions], options[:precommit]).commit
       else
         RakeCommit::Svn.new(options[:prompt_exclusions]).commit
       end
@@ -50,6 +51,9 @@ module RakeCommit
         end
         opts.on("-w", "--without-prompt PROMPT", "Skips the given prompt (author, feature, message)") do |prompt_exclusion|
           options[:prompt_exclusions] << prompt_exclusion
+        end
+        opts.on("-p", "--precommit SCRIPT", "command to run before commiting changes") do |command|
+          options[:precommit] = command
         end
       end
 

--- a/lib/rake_commit/git.rb
+++ b/lib/rake_commit/git.rb
@@ -1,10 +1,11 @@
 module RakeCommit
   class Git
 
-    def initialize(collapse_commits = true, incremental = false, prompt_exclusions = [])
+    def initialize(collapse_commits = true, incremental = false, prompt_exclusions = [], precommit = nil)
       @collapse_commits = collapse_commits
       @incremental = incremental
       @prompt_exclusions = prompt_exclusions
+      @precommit = precommit
     end
 
     def commit
@@ -36,6 +37,7 @@ module RakeCommit
     end
 
     def collapse_git_commits
+      RakeCommit::Shell.system(@precommit) unless @precommit.nil?
       add
       temp_commit
       reset_soft

--- a/lib/rake_commit/git_svn.rb
+++ b/lib/rake_commit/git_svn.rb
@@ -1,10 +1,12 @@
 module RakeCommit
   class GitSvn
-    def initialize(prompt_exclusions = [])
+    def initialize(prompt_exclusions = [], precommit = nil)
       @prompt_exclusions = prompt_exclusions
+      @precommit = precommit
     end
 
     def commit
+      RakeCommit::Shell.system(@precommit) unless @precommit.nil?
       git = RakeCommit::Git.new
       git.add
       git.status

--- a/lib/rake_commit/svn.rb
+++ b/lib/rake_commit/svn.rb
@@ -3,13 +3,15 @@ require 'fileutils'
 module RakeCommit
   class Svn
 
-    def initialize(prompt_exclusions = [])
+    def initialize(prompt_exclusions = [], precommit = nil)
       @prompt_exclusions = prompt_exclusions
+      @precommit = precommit
     end
 
     def commit
       if files_to_check_in?
         message = RakeCommit::CommitMessage.new(@prompt_exclusions).joined_message
+        RakeCommit::Shell.system(@precommit) unless @precommit.nil?
         add
         delete
         up

--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -322,6 +322,41 @@ class IntegrationTest < Test::Unit::TestCase
     end
   end
 
+  def test_allows_specifying_precommit_task
+    Dir.chdir(TMP_DIR) do
+      FileUtils.mkdir "git_repo"
+      Dir.chdir("git_repo") do
+        RakeCommit::Shell.system "echo 'task :default do; end' >> Rakefile"
+        create_git_repo
+      end
+
+      in_git_repo do
+        output = RakeCommit::Shell.backtick "yes | ../../../bin/rake_commit --precommit 'echo hi'"
+        assert_equal 0, $CHILD_STATUS
+        output_lines = output.split("\n")
+        assert_equal "hi", output_lines.first
+      end
+    end
+  end
+
+  def test_allows_specifying_precommit_task_in_dotfile
+    Dir.chdir(TMP_DIR) do
+      FileUtils.mkdir "git_repo"
+      Dir.chdir("git_repo") do
+        RakeCommit::Shell.system "echo 'task :default do; end' >> Rakefile"
+        create_git_repo
+      end
+
+      in_git_repo do
+        RakeCommit::Shell.system %%echo '--precommit "echo hi"' > .rake_commit%
+        output = RakeCommit::Shell.backtick "yes | ../../../bin/rake_commit"
+        assert_equal 0, $CHILD_STATUS
+        output_lines = output.split("\n")
+        assert_equal "hi", output_lines.first
+      end
+    end
+  end
+
   def create_git_repo
     RakeCommit::Shell.system "git init"
     RakeCommit::Shell.system "git add Rakefile"


### PR DESCRIPTION
allows you to remove trailing whitespace beforehand and not be left with a dirty repo after pushing.
