### PR TITLE
Add optional alternative 'what & why' prompts.

### DIFF
--- a/lib/rake_commit/commit.rb
+++ b/lib/rake_commit/commit.rb
@@ -20,7 +20,8 @@ module RakeCommit
         :incremental => false,
         :prompt_exclusions => [],
         :build_command => "rake",
-        :commit_message_wrap => nil # integer or nil
+        :commit_message_wrap => nil, # integer or nil
+        :commit_message_type => CommitMessage::MessageType::MESSAGE
       }
 
       if File.exists?(".rake_commit")
@@ -32,7 +33,7 @@ module RakeCommit
       if git_svn?
         RakeCommit::GitSvn.new(options[:prompt_exclusions]).commit
       elsif git?
-        RakeCommit::Git.new(options[:build_command], options[:collapse_commits], options[:rebase_only], options[:incremental], options[:prompt_exclusions], options[:precommit], options[:commit_message_wrap]).commit
+        RakeCommit::Git.new(options[:build_command], options[:collapse_commits], options[:rebase_only], options[:incremental], options[:prompt_exclusions], options[:precommit], options[:commit_message_wrap], options[:commit_message_type]).commit
       else
         RakeCommit::Svn.new(options[:prompt_exclusions]).commit
       end
@@ -66,6 +67,9 @@ module RakeCommit
         end
         opts.on("--word-wrap [80]", "word wrap the commit message (default no wrap)") do |commit_message_wrap|
           options[:commit_message_wrap] = commit_message_wrap.to_i
+        end
+        opts.on("-m", "--message-type [MESSAGE|WHATWHY]", "the type of commit message to prompt for (only works on Git)") do |commit_message_type|
+          options[:commit_message_type] = commit_message_type.downcase
         end
       end
 

--- a/lib/rake_commit/commit_message.rb
+++ b/lib/rake_commit/commit_message.rb
@@ -2,13 +2,31 @@ require 'word_wrap'
 
 module RakeCommit
   class CommitMessage
+    module MessageType
+      MESSAGE = "message"
+      WHAT_AND_WHY = "whatwhy"
+    end
+
+    SUBJECT_MAX_LENGTH = 50
 
     attr_reader :author, :feature, :message
 
-    def initialize(prompt_exclusions = [])
+    def initialize(prompt_exclusions = [], type = MessageType::MESSAGE)
       @author = RakeCommit::PromptLine.new("author", prompt_exclusions).prompt
       @feature = RakeCommit::PromptLine.new("feature", prompt_exclusions).prompt
-      @message = RakeCommit::PromptLine.new("message", prompt_exclusions).prompt
+      @message = case type
+        when MessageType::MESSAGE
+          RakeCommit::PromptLine.new("message", prompt_exclusions).prompt
+        when MessageType::WHAT_AND_WHY
+          what = RakeCommit::PromptLine.new("what", prompt_exclusions).prompt
+          why = RakeCommit::PromptLine.new("why", prompt_exclusions).prompt
+
+          subject_space_remaining = SUBJECT_MAX_LENGTH - @feature.length
+          truncated_what = what[0...subject_space_remaining]
+          subject = RakeCommit::PromptLine.new("subject", prompt_exclusions, truncated_what).prompt
+
+          create_message_with_subject_what_and_why(subject, what, why)
+        end
     end
 
     def joined_message(wrap = nil)
@@ -21,6 +39,22 @@ module RakeCommit
       message = [@author, @feature, @message].compact.join(' - ')
       message = WordWrap.ww(message, wrap) if wrap
       message
+    end
+
+    private
+
+    def create_message_with_subject_what_and_why(subject, what, why)
+      <<-EOS
+#{subject}
+
+What
+===
+#{what}
+
+Why
+===
+#{why}
+EOS
     end
   end
 end

--- a/lib/rake_commit/git.rb
+++ b/lib/rake_commit/git.rb
@@ -3,7 +3,7 @@ require 'shellwords'
 module RakeCommit
   class Git
 
-    def initialize(build_command, collapse_commits = true, rebase_only = false, incremental = false, prompt_exclusions = [], precommit = nil, commit_message_wrap = nil)
+    def initialize(build_command, collapse_commits = true, rebase_only = false, incremental = false, prompt_exclusions = [], precommit = nil, commit_message_wrap = nil, commit_message_type = MessageType::MESSAGE)
       @build_command = build_command
       @collapse_commits = collapse_commits
       @rebase_only = rebase_only
@@ -11,6 +11,7 @@ module RakeCommit
       @prompt_exclusions = prompt_exclusions
       @precommit = precommit
       @commit_message_wrap = commit_message_wrap
+      @commit_message_type = commit_message_type
     end
 
     def commit
@@ -76,7 +77,7 @@ module RakeCommit
     end
 
     def incremental_commit
-      commit_message = RakeCommit::CommitMessage.new(@prompt_exclusions)
+      commit_message = RakeCommit::CommitMessage.new(@prompt_exclusions, @commit_message_type)
       unless commit_message.author.nil?
         RakeCommit::Shell.system("git config user.name #{Shellwords.shellescape(commit_message.author)}")
       end

--- a/lib/rake_commit/prompt_line.rb
+++ b/lib/rake_commit/prompt_line.rb
@@ -5,9 +5,10 @@ module RakeCommit
   class PromptLine
     include Readline
 
-    def initialize(attribute, prompt_exclusions = [])
+    def initialize(attribute, prompt_exclusions = [], default_value = nil)
       @attribute = attribute
       @prompt_exclusions = prompt_exclusions
+      @default_value = default_value
     end
 
     def prompt
@@ -16,6 +17,7 @@ module RakeCommit
       puts "\n"
       puts "previous #{@attribute}: #{previous_input}" if previous_input
 
+      set_readline_default_input(@default_value) if @default_value
       set_readline_history
 
       input = nil
@@ -37,6 +39,14 @@ module RakeCommit
 
     def append_history(input)
       File.open(history_file, "a") { |f| f.puts(input) }
+    end
+
+    def set_readline_default_input(default_input)
+      Readline.pre_input_hook = lambda do
+        Readline.insert_text(default_input)
+        Readline.redisplay
+        Readline.pre_input_hook = nil
+      end
     end
 
     def previous_input

--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -328,6 +328,35 @@ class IntegrationTest < Test::Unit::TestCase
     end
   end
 
+  def test_commit_with_message_type_message
+    Dir.chdir(TMP_DIR) do
+      create_git_repo
+
+      in_git_repo do
+        RakeCommit::Shell.system "touch new_file"
+        RakeCommit::Shell.backtick("printf 'test-author\ntest-feature\ntest-message\n' | ../../../bin/rake_commit -m message", false).split("\n")
+
+        log_lines = RakeCommit::Shell.backtick("git log").split("\n")
+        assert_operator log_lines.grep(/test-feature - test-message/).length, :>, 0
+      end
+    end
+  end
+
+  def test_commit_with_message_type_what_why
+    Dir.chdir(TMP_DIR) do
+      create_git_repo
+
+      in_git_repo do
+        RakeCommit::Shell.system "touch new_file"
+        RakeCommit::Shell.backtick("printf 'test-author\ntest-feature\ntest-what\ntest-why\ntest-subject\n' | ../../../bin/rake_commit -m whatwhy", false)
+
+        # note: test-whattest-subject is because the feature and what is offered as the subject, and in the test test-subject is being appended to that.
+        log_lines = RakeCommit::Shell.backtick("git log")
+        assert_not_nil log_lines.match(/    test-feature - test-whattest-subject\n    \n    What\n    ===\n    test-what\n    \n    Why\n    ===\n    test-why/m)
+      end
+    end
+  end
+
   def test_without_author_does_not_prompt_for_author
     Dir.chdir(TMP_DIR) do
       create_git_repo


### PR DESCRIPTION
What
===
Optionally collect the git message as what, why and a short subject
line. Only used by the `Git` integration. Long messages are word wrapped, default off.

Why
===
So that users can optionally use this format instead of entering a
single block commit message. Limiting commit messages to have a single
what accompanied by a why supports a third party looking at the diff
know what the intentions and reasons for the change were without needing
to hypothesise.