### PR TITLE
Added word wrapping, default off.

### DIFF
--- a/lib/rake_commit/commit.rb
+++ b/lib/rake_commit/commit.rb
@@ -19,7 +19,8 @@ module RakeCommit
         :collapse_commits => true,
         :incremental => false,
         :prompt_exclusions => [],
-        :build_command => "rake"
+        :build_command => "rake",
+        :commit_message_wrap => nil # integer or nil
       }
 
       if File.exists?(".rake_commit")
@@ -31,7 +32,7 @@ module RakeCommit
       if git_svn?
         RakeCommit::GitSvn.new(options[:prompt_exclusions]).commit
       elsif git?
-        RakeCommit::Git.new(options[:build_command], options[:collapse_commits], options[:rebase_only], options[:incremental], options[:prompt_exclusions], options[:precommit]).commit
+        RakeCommit::Git.new(options[:build_command], options[:collapse_commits], options[:rebase_only], options[:incremental], options[:prompt_exclusions], options[:precommit], options[:commit_message_wrap]).commit
       else
         RakeCommit::Svn.new(options[:prompt_exclusions]).commit
       end
@@ -62,6 +63,9 @@ module RakeCommit
         end
         opts.on("-b", "--build-command SCRIPT", "the command that verifies the commit, defaults to rake") do |command|
           options[:build_command] = command
+        end
+        opts.on("--word-wrap [80]", "word wrap the commit message (default no wrap)") do |commit_message_wrap|
+          options[:commit_message_wrap] = commit_message_wrap.to_i
         end
       end
 

--- a/lib/rake_commit/commit_message.rb
+++ b/lib/rake_commit/commit_message.rb
@@ -1,3 +1,5 @@
+require 'word_wrap'
+
 module RakeCommit
   class CommitMessage
 
@@ -9,12 +11,16 @@ module RakeCommit
       @message = RakeCommit::PromptLine.new("message", prompt_exclusions).prompt
     end
 
-    def joined_message
-      [@feature, @message].compact.join(' - ')
+    def joined_message(wrap = nil)
+      message = [@feature, @message].compact.join(' - ')
+      message = WordWrap.ww(message, wrap) if wrap
+      message
     end
 
-    def joined_message_with_author
-      [@author, @feature, @message].compact.join(' - ')
+    def joined_message_with_author(wrap = nil)
+      message = [@author, @feature, @message].compact.join(' - ')
+      message = WordWrap.ww(message, wrap) if wrap
+      message
     end
   end
 end

--- a/lib/rake_commit/git.rb
+++ b/lib/rake_commit/git.rb
@@ -3,13 +3,14 @@ require 'shellwords'
 module RakeCommit
   class Git
 
-    def initialize(build_command, collapse_commits = true, rebase_only = false, incremental = false, prompt_exclusions = [], precommit = nil)
+    def initialize(build_command, collapse_commits = true, rebase_only = false, incremental = false, prompt_exclusions = [], precommit = nil, commit_message_wrap = nil)
       @build_command = build_command
       @collapse_commits = collapse_commits
       @rebase_only = rebase_only
       @incremental = incremental
       @prompt_exclusions = prompt_exclusions
       @precommit = precommit
+      @commit_message_wrap = commit_message_wrap
     end
 
     def commit
@@ -79,7 +80,7 @@ module RakeCommit
       unless commit_message.author.nil?
         RakeCommit::Shell.system("git config user.name #{Shellwords.shellescape(commit_message.author)}")
       end
-      message = commit_message.joined_message
+      message = commit_message.joined_message(@commit_message_wrap)
       RakeCommit::Shell.system("git commit -m #{Shellwords.shellescape(message)}")
     end
 

--- a/rake_commit.gemspec
+++ b/rake_commit.gemspec
@@ -15,6 +15,7 @@ Gem::Specification.new do |s|
   s.executables = ['rake_commit']
 
   s.add_runtime_dependency 'rake', '>= 0.9.2.2', '< 11'
+  s.add_runtime_dependency 'word_wrap', '~> 1.0'
 
   s.add_development_dependency 'mocha', '0.9.12'
   s.add_development_dependency 'test-unit', '~> 3.1', '>= 3.1.5'


### PR DESCRIPTION
What
===
Added word wrapping to `git` messages. Off by default.

Why
===
`git` messages get long and it's common place to wrap them at 80
characters.