### PR TITLE
Add a option `-l` for setting the word wrap limit.

### DIFF
--- a/lib/rake_commit/commit.rb
+++ b/lib/rake_commit/commit.rb
@@ -64,7 +64,7 @@ module RakeCommit
         opts.on("-b", "--build-command SCRIPT", "the command that verifies the commit, defaults to rake") do |command|
           options[:build_command] = command
         end
-        opts.on("--word-wrap [80]", "word wrap the commit message (default no wrap)") do |commit_message_wrap|
+        opts.on("-l", "--word-wrap [80]", "word wrap the commit message (default no wrap)") do |commit_message_wrap|
           options[:commit_message_wrap] = commit_message_wrap.to_i
         end
       end

--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -314,6 +314,20 @@ class IntegrationTest < Test::Unit::TestCase
     end
   end
 
+  def test_commit_with_word_wrap_short_on_and_a_really_long_message
+    Dir.chdir(TMP_DIR) do
+      create_git_repo
+
+      in_git_repo do
+        RakeCommit::Shell.system "touch new_file"
+        out = RakeCommit::Shell.backtick("printf 'test-author\ntest-feature\nit is very long and goes on for at least 80 characters, its super long yo, so long, very long. doesnt get much longer than this. this is not a good commit message.\n\n' | ../../../bin/rake_commit -l 80", false)
+
+        log_lines = RakeCommit::Shell.backtick("git log")
+        assert_match(/    test-feature - it is very long and goes on for at least 80 characters, its\n    super long yo, so long, very long\. doesnt get much longer than this\. this is\n    not a good commit message\./m, log_lines)
+      end
+    end
+  end
+
   def test_commit_with_word_wrap_on_and_a_really_long_message_with_a_super_long_word
     Dir.chdir(TMP_DIR) do
       create_git_repo


### PR DESCRIPTION
# What

Add a short option `-l` for setting the word wrap limit.
# Why

`--word-wrap` is really long to type, and it is the only option that
doesn't have a short version.
